### PR TITLE
allow passing filter with feature manager

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -1,8 +1,8 @@
 import { IContainer } from './interface/container.interface';
-import { Class } from './types';
+import { AnyClass } from './types';
 
 class DefaultContainer implements IContainer {
-  get<T>(anyClass: Class<T>): T {
+  get<T>(anyClass: AnyClass<T>): T {
     return new anyClass();
   }
 }

--- a/src/feature-manager.ts
+++ b/src/feature-manager.ts
@@ -9,11 +9,10 @@ import { containerProvider } from './container';
 export class FeatureManager {
   constructor(private readonly environment: string) {}
 
-  with() {
-    return this;
-  }
-
-  async isEnabled(feature: IFeature | string, filters: readonly IFeatureFilter[] = []): Promise<boolean> {
+  async isEnabled(
+    feature: IFeature | string,
+    filters: readonly IFeatureFilter[] = []
+  ): Promise<boolean> {
     const featureName = typeof feature === 'string' ? feature : feature['name'];
     const featureFlagOptions = featureFlagStore.get(this.environment, featureName);
 
@@ -21,9 +20,9 @@ export class FeatureManager {
       return false;
     }
 
-    const allFilters = [...(featureFlagOptions?.filters || [])];
+    const allFilters = [...(featureFlagOptions?.filters || []), ...filters];
 
-    for (const filter of filters) {
+    for (const filter of allFilters) {
       const filterHandler = Reflect.getMetadata(FEATURE_FILTER_METADATA, filter.constructor);
       const filterHandlerInstance = containerProvider
         .resolveContainer()

--- a/src/feature-manager.ts
+++ b/src/feature-manager.ts
@@ -3,12 +3,17 @@ import { featureFlagStore } from './feature-flag.store';
 import { FEATURE_FILTER_METADATA } from './decorator/constants';
 import { IFeatureFilterHandler } from './interface/feature-filter-handler.interface';
 import { IFeature } from './interface/feature.interface';
+import { IFeatureFilter } from './interface/feature-filter.interface';
 import { containerProvider } from './container';
 
 export class FeatureManager {
   constructor(private readonly environment: string) {}
 
-  async isEnabled(feature: IFeature | string): Promise<boolean> {
+  with() {
+    return this;
+  }
+
+  async isEnabled(feature: IFeature | string, filters: readonly IFeatureFilter[] = []): Promise<boolean> {
     const featureName = typeof feature === 'string' ? feature : feature['name'];
     const featureFlagOptions = featureFlagStore.get(this.environment, featureName);
 
@@ -16,13 +21,14 @@ export class FeatureManager {
       return false;
     }
 
-    const filters = featureFlagOptions?.filters || [];
+    const allFilters = [...(featureFlagOptions?.filters || [])];
 
     for (const filter of filters) {
       const filterHandler = Reflect.getMetadata(FEATURE_FILTER_METADATA, filter.constructor);
       const filterHandlerInstance = containerProvider
         .resolveContainer()
         .get<IFeatureFilterHandler>(filterHandler);
+
       const evaluatedResult = await filterHandlerInstance.evaluate(filter);
       if (evaluatedResult) return true;
     }

--- a/src/interface/container.interface.ts
+++ b/src/interface/container.interface.ts
@@ -1,5 +1,5 @@
-import { Class } from '../types';
+import { AnyClass } from '../types';
 
 export interface IContainer {
-  get<T>(anyClass: Class<T>, options?: Record<string, any>): T;
+  get<T>(anyClass: AnyClass<T>, options?: Record<string, any>): T;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import { IFeatureFilter } from './interface/feature-filter.interface';
 
-export interface Class<T> {
+export interface AnyClass<T> {
   new (...args: any[]): T;
 }
 

--- a/test/feature-flag-filter.spec.ts
+++ b/test/feature-flag-filter.spec.ts
@@ -31,7 +31,7 @@ describe('Feature Flag Filter', () => {
     })
     class HostReport implements IFeature {}
 
-    expect(await featureManager.isEnabled(HostReport.name)).toEqual(true);
+    expect(await featureManager.isEnabled(HostReport)).toEqual(true);
   });
 
   it('feature should be disabled with enabled:false even if filters resolves to true', async () => {
@@ -43,7 +43,7 @@ describe('Feature Flag Filter', () => {
     })
     class HostReport implements IFeature {}
 
-    expect(await featureManager.isEnabled(HostReport.name)).toEqual(false);
+    expect(await featureManager.isEnabled(HostReport)).toEqual(false);
   });
 
   it('feature should be enabled when one of the filter evaluates to true', async () => {
@@ -55,7 +55,7 @@ describe('Feature Flag Filter', () => {
     })
     class HostReport implements IFeature {}
 
-    expect(await featureManager.isEnabled(HostReport.name)).toEqual(true);
+    expect(await featureManager.isEnabled(HostReport)).toEqual(true);
   });
 
   it('feature should be enabled with enabled:true and no filter is specified', async () => {
@@ -64,7 +64,7 @@ describe('Feature Flag Filter', () => {
     @FeatureFlag('production', { enabled: true })
     class HostReport implements IFeature {}
 
-    expect(await featureManager.isEnabled(HostReport.name)).toEqual(true);
+    expect(await featureManager.isEnabled(HostReport)).toEqual(true);
   });
 
   it('feature should be disabled with enabled:false and no filter is specified', async () => {
@@ -73,6 +73,15 @@ describe('Feature Flag Filter', () => {
     @FeatureFlag('production', { enabled: false })
     class HostReport implements IFeature {}
 
-    expect(await featureManager.isEnabled(HostReport.name)).toEqual(false);
+    expect(await featureManager.isEnabled(HostReport)).toEqual(false);
+  });
+
+  it('feature filters can be added right before evaluation', async () => {
+    const featureManager = new FeatureManager('production');
+
+    @FeatureFlag('production', { enabled: true, filters: [new GenericFilter(false)] })
+    class HostReport implements IFeature {}
+
+    expect(await featureManager.isEnabled(HostReport, [new GenericFilter(true)])).toEqual(true);
   });
 });

--- a/test/feature-flag.manager.spec.ts
+++ b/test/feature-flag.manager.spec.ts
@@ -19,7 +19,7 @@ describe('Feature Flag Manager', () => {
     @FeatureFlag('production', { enabled: false })
     class HostReport implements IFeature {}
 
-    expect(await featureManager.isEnabled(HostReport.name)).toEqual(false);
+    expect(await featureManager.isEnabled(HostReport)).toEqual(false);
   });
 
   it('feature should be enabled when default value is true', async () => {
@@ -28,6 +28,6 @@ describe('Feature Flag Manager', () => {
     @FeatureFlag('production', { enabled: true })
     class HostReport implements IFeature {}
 
-    expect(await featureManager.isEnabled(HostReport.name)).toEqual(true);
+    expect(await featureManager.isEnabled(HostReport)).toEqual(true);
   });
 });


### PR DESCRIPTION
There are times when a feature needs to be validated based on runtime data. This PR allows passing filters when calling `featureManager.isEnabled`